### PR TITLE
Allow for common IAM group, policy, role, and user configurations

### DIFF
--- a/tasks/entities_list.yml
+++ b/tasks/entities_list.yml
@@ -3,7 +3,15 @@
 - name: set fact for configured IAM {{ _aws_iam_entity_type }}s
   set_fact:
     _aws_iam_configured_entities: >
-      {{ vars["aws_iam_" + _aws_iam_entity_type + "s"] | default([]) }}
+      {{
+          vars["aws_iam_" + _aws_iam_entity_type + "s_common"] | default({})
+        |
+        combine(
+          vars["aws_iam_" + _aws_iam_entity_type + "s"]        | default({})
+        )
+        |
+        default({})
+      }}
     _aws_iam_Entity_Type: '{{ _aws_iam_entity_type | capitalize }}'
 
 - name: set fact for existing IAM {{ _aws_iam_entity_type }}s

--- a/tasks/entity_create.yml
+++ b/tasks/entity_create.yml
@@ -7,11 +7,6 @@
       https://console.aws.amazon.com/iam/home#{{
         _aws_iam_entity_type }}s/{{ _aws_iam_entity_name }}
 
-- name: set configuration fact for IAM {{ _aws_iam_entity_type }}s
-  set_fact:
-    _aws_iam_configured_entities: >
-      {{ vars["aws_iam_" + _aws_iam_entity_type + "s"] }}
-
 - name: create {{ _aws_iam_e }}
   iam:
     profile:        '{{ aws_profile }}'

--- a/tasks/policy_list.yml
+++ b/tasks/policy_list.yml
@@ -3,7 +3,15 @@
 - name: set configured IAM managed policies fact
   set_fact:
     _aws_iam_configured_policies: >
-      {{ vars["aws_iam_policies"] | default([]) }}
+      {{
+          vars["aws_iam_policies_common"] | default({})
+        |
+        combine(
+          vars["aws_iam_policies"]        | default({})
+        )
+        |
+        default({})
+      }}
 
 - name: initialize existing IAM managed policies fact
   set_fact:


### PR DESCRIPTION
For IAM entities or managed policies that are identical between accounts, this allows those to be specified in group variables:

* `aws_iam_groups_common`
* `aws_iam_policies_common`
* `aws_iam_roles_common`
* `aws_iam_users_common`

This is similar to how common security groups are handled in https://github.com/bretmartin/ansible-role-aws-vpc/.