### PR TITLE
Add AWS client configuration generators

### DIFF
--- a/tasks/generate_aws-extend-switch-roles_configuration.yml
+++ b/tasks/generate_aws-extend-switch-roles_configuration.yml
@@ -1,0 +1,18 @@
+---
+
+- name: require that at least one user be specified
+  assert:
+    fail_msg: You must specify a comma-delimited list of at least one user
+    that: aws_iam_target_user is defined
+
+- name: set target user fact
+  set_fact:
+    _aws_iam_target_users: '{{ aws_iam_target_user.split(",") }}'
+
+- name: generate aws-extend-switch-roles configuration
+  template:
+    dest: '{{ playbook_dir }}/aws-extend-switch-roles--{{ user }}.ini'
+    src: aws-extend-switch-roles.ini.j2
+  loop: '{{ _aws_iam_target_users }}'
+  loop_control:
+    loop_var: user

--- a/tasks/generate_aws_config.yml
+++ b/tasks/generate_aws_config.yml
@@ -1,0 +1,18 @@
+---
+
+- name: require that at least one user be specified
+  assert:
+    fail_msg: You must specify a comma-delimited list of at least one user
+    that: aws_iam_target_user is defined
+
+- name: set target user fact
+  set_fact:
+    _aws_iam_target_users: '{{ aws_iam_target_user.split(",") }}'
+
+- name: generate ~/.aws/config
+  template:
+    dest: '{{ playbook_dir }}/aws-config--{{ user }}.ini'
+    src: aws-config.ini.j2
+  loop: '{{ _aws_iam_target_users }}'
+  loop_control:
+    loop_var: user

--- a/templates/aws-config.ini.j2
+++ b/templates/aws-config.ini.j2
@@ -1,0 +1,26 @@
+{% for account in (groups["aws-accounts"] | sort) %}
+{%
+     if
+       (
+         "aws_iam_roles" in hostvars[account]
+         and
+         user in hostvars[account]["aws_iam_roles"]
+       ) or (
+         "aws_iam_roles_common" in hostvars[account]
+         and
+         user in hostvars[account]["aws_iam_roles_common"]
+       )
+%}
+
+[profile {{ hostvars[account]["aws_profile"] }}]
+region = us-east-1
+{%     if account != "aws-account-" + aws_profile %}
+role_arn = arn:aws:iam::{{ hostvars[account]["aws_account"] }}:role/{{ user }}
+{%     endif %}
+s3 =
+    signature_version = s3v4
+{%     if account != "aws-account-" + aws_profile %}
+source_profile = {{ aws_profile }}
+{%     endif %}
+{%   endif %}
+{% endfor %}

--- a/templates/aws-extend-switch-roles.ini.j2
+++ b/templates/aws-extend-switch-roles.ini.j2
@@ -1,0 +1,21 @@
+[{{ aws_profile }}]
+aws_account_id = {{ aws_profile }}
+{% for account in (groups["aws-accounts"] | sort) %}
+{%
+     if
+       (
+         "aws_iam_roles" in hostvars[account]
+         and
+         user in hostvars[account]["aws_iam_roles"]
+       ) or (
+         "aws_iam_roles_common" in hostvars[account]
+         and
+         user in hostvars[account]["aws_iam_roles_common"]
+       )
+%}
+
+[{{ user }} @ {{ hostvars[account]["aws_profile"] }}]
+role_arn = arn:aws:iam::{{ hostvars[account]["aws_account"] }}:role/{{ user }}
+source_profile = {{ aws_profile }}
+{%   endif %}
+{% endfor %}


### PR DESCRIPTION
To test this, check out this branch and [the corresponding one in the parent repository](https://github.com/h3biomed/h3-ansible/pull/57) (which adds necessary `Makefile` configuration). Then, you can run

* `make aws-iam task=generate_aws_config user=USERNAME[,...]`
  * This will create a file `aws-config--USERNAME.ini` in your h3-ansible directory for each username you specified.
  * The named user can use this file as their `~/.aws/config` file.

* `make aws-iam task=generate_aws-extend-switch-roles_configuration user=USERNAME[,...]`
  * This will create a file `aws-extend-switch-roles--USERNAME.ini` in your h3-ansible directory for each username you specified.
  * The named user can use this file's contents to configure [aws-extend-switch-roles](https://github.com/tilfin/aws-extend-switch-roles/), if they have access to more than 5 IAM roles (the limit on stock AWS Console's role save slots).

My expectation is that when providing someone access to a set of IAM roles, we'll run these task lists and provide them with the output files to get them started. We can ask users who are comfortable using Ansible to generate their own.