### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/entity_create.yml
+++ b/tasks/entity_create.yml
@@ -23,7 +23,8 @@
   register: _aws_iam_create
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created <a href="{{ _aws_iam_eurl }}">{{ _aws_iam_e }}</a>

--- a/tasks/entity_delete.yml
+++ b/tasks/entity_delete.yml
@@ -29,7 +29,8 @@
   register: _aws_iam_remove
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       deleted <b>{{ _aws_iam_e }}</b>

--- a/tasks/entity_sync_assume_role_policy.yml
+++ b/tasks/entity_sync_assume_role_policy.yml
@@ -22,7 +22,8 @@
                 --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           updated role assumption policy for

--- a/tasks/entity_sync_inline_policies_add.yml
+++ b/tasks/entity_sync_inline_policies_add.yml
@@ -12,7 +12,8 @@
   with_items: '{{ _aws_iam_added_inline_policies }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       added inline

--- a/tasks/entity_sync_inline_policies_delete.yml
+++ b/tasks/entity_sync_inline_policies_delete.yml
@@ -9,7 +9,8 @@
   with_items: '{{ _aws_iam_deleted_inline_policies }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       deleted inline

--- a/tasks/entity_sync_inline_policies_update.yml
+++ b/tasks/entity_sync_inline_policies_update.yml
@@ -12,7 +12,8 @@
   with_items: '{{ _aws_iam_updated_inline_policies }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       modified existing inline

--- a/tasks/entity_sync_managed_policies_attach.yml
+++ b/tasks/entity_sync_managed_policies_attach.yml
@@ -9,7 +9,8 @@
   with_items: '{{ _aws_iam_added_managed_policies }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       attached managed

--- a/tasks/entity_sync_managed_policies_detach.yml
+++ b/tasks/entity_sync_managed_policies_detach.yml
@@ -9,7 +9,8 @@
   with_items: '{{ _aws_iam_removed_managed_policies }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       detached managed

--- a/tasks/entity_sync_user_groups.yml
+++ b/tasks/entity_sync_user_groups.yml
@@ -33,7 +33,8 @@
   with_items: '{{ _aws_iam_added_groups }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       added <a href="{{ _aws_iam_eurl }}">{{ _aws_iam_e }}</a> to
@@ -58,7 +59,8 @@
   with_items: '{{ _aws_iam_removed_groups }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       removed <a href="{{ _aws_iam_eurl }}">{{ _aws_iam_e }}</a> from

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,8 @@
 
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-iam</b>
@@ -138,7 +139,8 @@
 
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-iam</b>

--- a/tasks/policy_create.yml
+++ b/tasks/policy_create.yml
@@ -29,7 +29,8 @@
             --profile '{{ aws_profile }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created <a href="{{ _aws_iam_purl }}">{{ _aws_iam_p }}</a>

--- a/tasks/policy_delete.yml
+++ b/tasks/policy_delete.yml
@@ -92,7 +92,8 @@
             --profile '{{ aws_profile }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       deleted <b>{{ _aws_iam_p }}</b>

--- a/tasks/policy_sync.yml
+++ b/tasks/policy_sync.yml
@@ -82,7 +82,8 @@
         != _aws_iam_configured_policy_document
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           updated <a href="{{ _aws_iam_purl }}">{{ _aws_iam_p }}</a>

--- a/tasks/saml_provider_create.yml
+++ b/tasks/saml_provider_create.yml
@@ -17,7 +17,8 @@
             --profile '{{ aws_profile }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created <a href="{{ _aws_iam_idpurl }}">{{ _aws_iam_idp }}</a>

--- a/tasks/saml_provider_delete.yml
+++ b/tasks/saml_provider_delete.yml
@@ -15,7 +15,8 @@
             --profile '{{ aws_profile }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       deleted <b>{{ _aws_iam_idp }}</b>

--- a/tasks/saml_provider_sync.yml
+++ b/tasks/saml_provider_sync.yml
@@ -42,7 +42,8 @@
                 --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           updated <a href="{{ _aws_iam_idpurl }}">{{ _aws_iam_idp }}</a>


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.