### PR TITLE
Manage AWS account password policies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
 - import_tasks: account_ids.yml
 
 
+- import_tasks: password_policy.yml
+
+
 - import_tasks: saml_provider_list.yml
 
 - include_tasks: saml_provider_create.yml

--- a/tasks/password_policy.yml
+++ b/tasks/password_policy.yml
@@ -1,0 +1,109 @@
+---
+
+- name: set IAM account password policy facts
+  set_fact:
+    _aws_iam_configured_password_policy: {}
+    _aws_iam_pp: IAM account password policy
+    _aws_iam_ppurl: >-
+      https://console.aws.amazon.com/iam/home#/account_settings
+
+- name: include map of Ansible {{ _aws_iam_pp }} parameters to AWS API names
+  include_vars: password_policy_map.yml
+
+- name: set fact for configured {{ _aws_iam_pp }}
+  set_fact:
+    _aws_iam_configured_password_policy: >
+      {{
+        _aws_iam_configured_password_policy
+        | combine({
+            _aws_iam_password_policy_map[item.key]:
+            item.value
+          })
+      }}
+  loop: >
+    {{
+                aws_iam_password_policy_common | default({})
+      | combine(aws_iam_password_policy        | default({}))
+      | default({})
+      | dict2items
+    }}
+
+- name: set fact for configured {{ _aws_iam_pp }} without implied attributes
+  set_fact:
+    _aws_iam_original_configured_password_policy: >
+      {{ _aws_iam_configured_password_policy }}
+
+- name: set implied policy attribute ExpirePasswords
+  set_fact:
+    _aws_iam_configured_password_policy: >
+      {{
+        _aws_iam_configured_password_policy
+        | combine({
+            "ExpirePasswords":
+            "MaxPasswordAge" in _aws_iam_configured_password_policy
+          })
+      }}
+  when: _aws_iam_configured_password_policy != {}
+
+- name: get existing {{ _aws_iam_pp }}
+  command: >
+    aws iam get-account-password-policy
+            --profile {{ aws_profile }}
+            --query PasswordPolicy
+  register: _aws_iam_existing_password_policy_command
+  changed_when: false
+  failed_when: false
+
+- name: initialize fact for existing {{ _aws_iam_pp }}
+  set_fact:
+    _aws_iam_existing_password_policy: {}
+
+- name: set fact for existing {{ _aws_iam_pp }}
+  set_fact:
+    _aws_iam_existing_password_policy: >
+      {{ _aws_iam_existing_password_policy_command.stdout | from_json }}
+  when: _aws_iam_existing_password_policy_command.stdout != ""
+
+- block: 
+
+  - name: update {{ _aws_iam_pp }}
+    command: >
+      aws iam update-account-password-policy
+              --cli-input-json '{{ _aws_iam_original_configured_password_policy
+                                   | to_json }}'
+              --profile {{ aws_profile }}
+    register: _aws_iam_update_account_password_policy
+    when: _aws_iam_configured_password_policy != {}
+
+  - name: call optional notifier
+    include_role:
+      name: '{{ notifier_role }}'
+    vars:
+      message: >
+        updated <a href="{{ _aws_iam_ppurl }}">{{ _aws_iam_pp }}</a>
+        in <a href="{{ _aws_iam_url }}">account {{ aws_profile }}</a>
+    when: >
+      notifier_role is defined and
+      _aws_iam_update_account_password_policy is changed
+
+  - name: delete {{ _aws_iam_pp }}
+    command: >
+      aws iam delete-account-password-policy
+              --profile {{ aws_profile }}
+    register: _aws_iam_delete_account_password_policy
+    when: _aws_iam_configured_password_policy == {}
+
+  - name: call optional notifier
+    include_role:
+      name: '{{ notifier_role }}'
+    vars:
+      message: >
+        deleted <a href="{{ _aws_iam_ppurl }}">{{ _aws_iam_pp }}</a>
+        from <a href="{{ _aws_iam_url }}">account {{ aws_profile }}</a>
+    when: >
+      notifier_role is defined and
+      _aws_iam_delete_account_password_policy is changed
+
+  when: >
+    _aws_iam_configured_password_policy
+    != _aws_iam_existing_password_policy

--- a/vars/password_policy_map.yml
+++ b/vars/password_policy_map.yml
@@ -1,0 +1,13 @@
+---
+
+_aws_iam_password_policy_map:
+  allow_password_change:   AllowUsersToChangePassword
+  expire_passwords:        ExpirePasswords
+  minimum_password_length: MinimumPasswordLength
+  password_expire:         HardExpiry
+  password_max_age:        MaxPasswordAge
+  password_reuse_prevent:  PasswordReusePrevention
+  require_lowercase:       RequireLowercaseCharacters
+  require_numbers:         RequireNumbers
+  require_symbols:         RequireSymbols
+  require_uppercase:       RequireUppercaseCharacters


### PR DESCRIPTION
This task lists adds support for configuring AWS account password policies, using `aws_iam_password_policy_common` (for groups to share a policy or policy elements) and `aws-iam_password_policy`. At runtime, those two hashes are merged, with the more-specific non-`_common` one winning. A sample `iam/password_policy.yml`:

```
---

aws_iam_password_policy:
  allow_password_change: true
  minimum_password_length: 6
  password_expire: false
  password_max_age: 90
  password_reuse_prevent: 10
  require_lowercase: true
  require_numbers: true
  require_symbols: false
  require_uppercase: true
```

I would normally match parameter names to the [AWS API names](https://docs.aws.amazon.com/IAM/latest/APIReference/API_PasswordPolicy.html), but in this case I've used the names that Ansible's [not-yet-in-a-final-release iam_password_policy module](https://docs.ansible.com/ansible/devel/modules/iam_password_policy_module.html) for future compatibility. This implementation uses the AWS CLI for now.